### PR TITLE
✨ Feat: Redis 캐시 레이어 추가 (#9)

### DIFF
--- a/cheerlot/build.gradle
+++ b/cheerlot/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	// Notion SDK
 	implementation 'com.github.seratch:notion-sdk-jvm-core:1.11.1'

--- a/cheerlot/src/main/java/com/gms/cheerlot/cache/CacheController.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/cache/CacheController.java
@@ -1,0 +1,22 @@
+package com.gms.cheerlot.cache;
+
+import com.gms.cheerlot.cache.dto.ResetResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/cache")
+@RequiredArgsConstructor
+public class CacheController {
+
+    private final CacheLoader cacheLoader;
+
+    @PostMapping("/reset")
+    public ResponseEntity<ResetResult> reset() {
+        ResetResult result = cacheLoader.reset();
+        return ResponseEntity.ok(result);
+    }
+}

--- a/cheerlot/src/main/java/com/gms/cheerlot/cache/CacheDataService.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/cache/CacheDataService.java
@@ -1,0 +1,90 @@
+package com.gms.cheerlot.cache;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gms.cheerlot.cheersong.domain.CheerSong;
+import com.gms.cheerlot.lineup.domain.Player;
+import com.gms.cheerlot.lineup.domain.Team;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CacheDataService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper redisObjectMapper;
+
+    private static final String KEY_TEAMS = "teams";
+    private static final String KEY_PLAYERS = "players";
+    private static final String KEY_CHEERSONGS = "cheersongs";
+
+    // ========== Team ==========
+
+    public List<Team> getTeams() {
+        return getFromRedis(KEY_TEAMS, new TypeReference<>() {});
+    }
+
+    public Optional<Team> getTeamByCode(String teamCode) {
+        return getTeams().stream()
+                .filter(t -> t.getTeamCode().equals(teamCode))
+                .findFirst();
+    }
+
+    // ========== Player ==========
+
+    public List<Player> getPlayers() {
+        return getFromRedis(KEY_PLAYERS, new TypeReference<>() {});
+    }
+
+    public List<Player> getPlayersByTeamCode(String teamCode) {
+        return getPlayers().stream()
+                .filter(p -> p.getTeamCode().equals(teamCode))
+                .toList();
+    }
+
+    public List<Player> getStartersByTeamCode(String teamCode) {
+        return getPlayers().stream()
+                .filter(p -> p.getTeamCode().equals(teamCode))
+                .filter(Player::isStarter)
+                .toList();
+    }
+
+    public Optional<Player> getPlayerByCode(String playerCode) {
+        return getPlayers().stream()
+                .filter(p -> p.getPlayerCode().equals(playerCode))
+                .findFirst();
+    }
+
+    // ========== CheerSong ==========
+
+    public List<CheerSong> getCheerSongs() {
+        return getFromRedis(KEY_CHEERSONGS, new TypeReference<>() {});
+    }
+
+    public List<CheerSong> getCheerSongsByPlayerCode(String playerCode) {
+        return getCheerSongs().stream()
+                .filter(cs -> cs.getPlayerCode().equals(playerCode))
+                .toList();
+    }
+
+    // ========== Helper ==========
+
+    private <T> T getFromRedis(String key, TypeReference<T> typeReference) {
+        String json = redisTemplate.opsForValue().get(key);
+        if (json == null) {
+            throw new IllegalStateException("캐시가 비어있습니다. 서버 시작 초기화되어야 합니다: " + key);
+        }
+
+        try {
+            return redisObjectMapper.readValue(json, typeReference);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Redis 조회 실패: " + key, e);
+        }
+    }
+}

--- a/cheerlot/src/main/java/com/gms/cheerlot/cache/CacheLoader.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/cache/CacheLoader.java
@@ -1,0 +1,65 @@
+package com.gms.cheerlot.cache;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gms.cheerlot.cache.dto.ResetResult;
+import com.gms.cheerlot.cheersong.domain.CheerSong;
+import com.gms.cheerlot.cheersong.repository.CheerSongRepository;
+import com.gms.cheerlot.lineup.domain.Player;
+import com.gms.cheerlot.lineup.domain.Team;
+import com.gms.cheerlot.lineup.repository.PlayerRepository;
+import com.gms.cheerlot.lineup.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CacheLoader {
+
+    private final StringRedisTemplate redisTemplate;
+    private final TeamRepository teamRepository;
+    private final PlayerRepository playerRepository;
+    private final CheerSongRepository cheerSongRepository;
+
+    private static final String KEY_TEAMS = "teams";
+    private static final String KEY_PLAYERS = "players";
+    private static final String KEY_CHEERSONGS = "cheersongs";
+    private final ObjectMapper redisObjectMapper;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        log.info("서버 시작 - 캐시 초기화 시작");
+        ResetResult result = reset();
+        log.info("캐시 초기화 완료 - teams: {}, players: {}, cheersongs: {}", result.teams(), result.players(), result.cheerSongs());
+    }
+
+    public ResetResult reset() {
+        redisTemplate.delete(List.of(KEY_TEAMS, KEY_PLAYERS, KEY_CHEERSONGS));
+
+        List<Team> teams = teamRepository.findAll();
+        List<Player> players = playerRepository.findAll();
+        List<CheerSong> cheerSongs = cheerSongRepository.findAll();
+
+        saveToRedis(KEY_TEAMS, teams);
+        saveToRedis(KEY_PLAYERS, players);
+        saveToRedis(KEY_CHEERSONGS, cheerSongs);
+
+        return new ResetResult(teams.size(), players.size(), cheerSongs.size());
+    }
+
+    private <T> void saveToRedis(String key, T data) {
+        try {
+            String json = redisObjectMapper.writeValueAsString(data);
+            redisTemplate.opsForValue().set(key, json);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Redis 저장 실패: " + key, e);
+        }
+    }
+}

--- a/cheerlot/src/main/java/com/gms/cheerlot/cache/dto/ResetResult.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/cache/dto/ResetResult.java
@@ -1,0 +1,7 @@
+package com.gms.cheerlot.cache.dto;
+
+public record ResetResult(
+        int teams,
+        int players,
+        int cheerSongs
+) {}

--- a/cheerlot/src/main/java/com/gms/cheerlot/cheersong/domain/CheerSong.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/cheersong/domain/CheerSong.java
@@ -1,10 +1,15 @@
 package com.gms.cheerlot.cheersong.domain;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class CheerSong {
     private Long id;
     private String playerCode;

--- a/cheerlot/src/main/java/com/gms/cheerlot/config/RedisConfig.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.gms.cheerlot.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+
+    @Bean
+    public ObjectMapper redisObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
+    }
+}

--- a/cheerlot/src/main/java/com/gms/cheerlot/lineup/domain/Player.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/lineup/domain/Player.java
@@ -1,10 +1,15 @@
 package com.gms.cheerlot.lineup.domain;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Player {
     private String playerCode;
     private String teamCode;
@@ -13,5 +18,5 @@ public class Player {
     private String position;
     private String batThrow;
     private Integer battingOrder;
-    private boolean isStarter;
+    private boolean starter;
 }

--- a/cheerlot/src/main/java/com/gms/cheerlot/lineup/domain/Team.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/lineup/domain/Team.java
@@ -1,13 +1,18 @@
 package com.gms.cheerlot.lineup.domain;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Team {
     private String teamCode;
     private String teamName;
@@ -15,6 +20,6 @@ public class Team {
     private String opponentTeamCode;
     private String starterPitcherName;
     private LocalDate lastGameDate;
-    private boolean isSeasonEnded;
+    private boolean seasonEnded;
     private LocalDateTime updatedAt;
 }

--- a/cheerlot/src/main/java/com/gms/cheerlot/lineup/repository/PlayerRepository.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/lineup/repository/PlayerRepository.java
@@ -124,7 +124,7 @@ public class PlayerRepository {
                 .position(getText(props, "position"))
                 .batThrow(getText(props, "bat_throw"))
                 .battingOrder(getNumber(props, "batting_order"))
-                .isStarter(getCheckbox(props, "is_starter"))
+                .starter(getCheckbox(props, "is_starter"))
                 .build();
     }
 

--- a/cheerlot/src/main/java/com/gms/cheerlot/lineup/repository/TeamRepository.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/lineup/repository/TeamRepository.java
@@ -172,7 +172,7 @@ public class TeamRepository {
                 .opponentTeamCode(getText(props, "opponent_team_code"))
                 .starterPitcherName(getText(props, "starter_pitcher_name"))
                 .lastGameDate(getDate(props, "last_game_date"))
-                .isSeasonEnded(getCheckbox(props, "is_season_ended"))
+                .seasonEnded(getCheckbox(props, "is_season_ended"))
                 .updatedAt(getDateTime(props, "updated_at"))
                 .build();
     }

--- a/cheerlot/src/main/java/com/gms/cheerlot/lineup/service/PlayerService.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/lineup/service/PlayerService.java
@@ -1,12 +1,11 @@
 package com.gms.cheerlot.lineup.service;
 
+import com.gms.cheerlot.cache.CacheDataService;
 import com.gms.cheerlot.cheersong.dto.CheerSongInfo;
-import com.gms.cheerlot.cheersong.repository.CheerSongRepository;
 import com.gms.cheerlot.cheersong.service.CheerSongService;
 import com.gms.cheerlot.lineup.domain.Player;
 import com.gms.cheerlot.lineup.dto.PlayerListResponse;
 import com.gms.cheerlot.lineup.dto.PlayerResponse;
-import com.gms.cheerlot.lineup.repository.PlayerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,12 +16,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PlayerService {
 
-    private final PlayerRepository playerRepository;
-    private final CheerSongRepository cheerSongRepository;
+    private final CacheDataService cacheDataService;
     private final CheerSongService cheerSongService;
 
     public PlayerListResponse getPlayers(String teamCode) {
-        List<PlayerResponse> players = playerRepository.findByTeamCode(teamCode).stream()
+        List<PlayerResponse> players = cacheDataService.getPlayersByTeamCode(teamCode).stream()
                 .map(this::toPlayerResponse)
                 .toList();
 
@@ -30,7 +28,7 @@ public class PlayerService {
     }
 
     public PlayerListResponse getStarterLineup(String teamCode) {
-        List<PlayerResponse> players = playerRepository.findStartersByTeamCode(teamCode).stream()
+        List<PlayerResponse> players = cacheDataService.getStartersByTeamCode(teamCode).stream()
                 .sorted(Comparator.comparing(Player::getBattingOrder))
                 .map(this::toPlayerResponse)
                 .toList();
@@ -39,14 +37,14 @@ public class PlayerService {
     }
 
     public PlayerResponse getPlayer(String playerCode) {
-        Player player = playerRepository.findByPlayerCode(playerCode)
+        Player player = cacheDataService.getPlayerByCode(playerCode)
                 .orElseThrow(() -> new IllegalArgumentException("선수를 찾을 수 없습니다: " + playerCode));
 
         return toPlayerResponse(player);
     }
 
     private PlayerResponse toPlayerResponse(Player player) {
-        List<CheerSongInfo> cheerSongs = cheerSongRepository.findByPlayerCode(player.getPlayerCode()).stream()
+        List<CheerSongInfo> cheerSongs = cacheDataService.getCheerSongsByPlayerCode(player.getPlayerCode()).stream()
                 .map(cs -> new CheerSongInfo(cs.getTitle(), cs.getLyrics(), cheerSongService.getAudioUrl(cs.getAudioFileName())))
                 .toList();
 

--- a/cheerlot/src/main/java/com/gms/cheerlot/lineup/service/TeamService.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/lineup/service/TeamService.java
@@ -1,8 +1,8 @@
 package com.gms.cheerlot.lineup.service;
 
+import com.gms.cheerlot.cache.CacheDataService;
 import com.gms.cheerlot.lineup.domain.Team;
 import com.gms.cheerlot.lineup.dto.TeamResponse;
-import com.gms.cheerlot.lineup.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,10 +10,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TeamService {
 
-    private final TeamRepository teamRepository;
+    private final CacheDataService cacheDataService;
 
     public TeamResponse getTeam(String teamCode) {
-        Team team = teamRepository.findByTeamCode(teamCode)
+        Team team = cacheDataService.getTeamByCode(teamCode)
                 .orElseThrow(() -> new IllegalArgumentException("팀을 찾을 수 없습니다: " + teamCode));
 
         return new TeamResponse(

--- a/cheerlot/src/main/resources/application.properties
+++ b/cheerlot/src/main/resources/application.properties
@@ -13,3 +13,7 @@ notion.api.key=${NOTION_API_KEY:}
 notion.database.player-id=${NOTION_PLAYER_DB_ID:}
 notion.database.team-id=${NOTION_TEAM_DB_ID:}
 notion.database.cheersong-id=${NOTION_CHEERSONG_DB_ID:}
+
+# Redis
+spring.data.redis.host=${SPRING_DATA_REDIS_HOST:localhost}
+spring.data.redis.port=${SPRING_DATA_REDIS_PORT:6379}


### PR DESCRIPTION
  ## 개요
  Notion API 응답 속도 개선을 위해 Redis 캐시 레이어 추가

  ## 변경 사항
  - Redis 설정 및 의존성 추가
  - 서버 시작 시 Notion 데이터를 Redis에 자동 로드 (CacheLoader)
  - 캐시 우선 조회 서비스 구현 (CacheDataService)
  - 캐시 리셋 API 엔드포인트 추가 (`POST /api/cache/reset`)
  - 도메인 클래스 JSON 직렬화 지원
  - 기존 Service가 캐시를 통해 데이터 조회하도록 변경

  ## 관련 이슈
  - closes #9