### PR TITLE
🐛 Fix: 응원가 가사 줄바꿈이 리터럴 \n으로 노출되는 버그 수정 (#17)

### DIFF
--- a/cheerlot/src/main/java/com/gms/cheerlot/cheersong/repository/CheerSongRepository.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/cheersong/repository/CheerSongRepository.java
@@ -69,10 +69,14 @@ public class CheerSongRepository {
         }
 
         if (prop.getRichText() != null && !prop.getRichText().isEmpty()) {
-            return prop.getRichText().get(0).getPlainText();
+            return prop.getRichText().stream()
+                    .map(PageProperty.RichText::getPlainText)
+                    .collect(java.util.stream.Collectors.joining());
         }
         if (prop.getTitle() != null && !prop.getTitle().isEmpty()) {
-            return prop.getTitle().get(0).getPlainText();
+            return prop.getTitle().stream()
+                    .map(PageProperty.RichText::getPlainText)
+                    .collect(java.util.stream.Collectors.joining());
         }
         return null;
     }

--- a/cheerlot/src/main/java/com/gms/cheerlot/lineup/repository/PlayerRepository.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/lineup/repository/PlayerRepository.java
@@ -135,10 +135,14 @@ public class PlayerRepository {
         }
 
         if (prop.getRichText() != null && !prop.getRichText().isEmpty()) {
-            return prop.getRichText().get(0).getPlainText();
+            return prop.getRichText().stream()
+                    .map(PageProperty.RichText::getPlainText)
+                    .collect(java.util.stream.Collectors.joining());
         }
         if (prop.getTitle() != null && !prop.getTitle().isEmpty()) {
-            return prop.getTitle().get(0).getPlainText();
+            return prop.getTitle().stream()
+                    .map(PageProperty.RichText::getPlainText)
+                    .collect(java.util.stream.Collectors.joining());
         }
         return null;
     }

--- a/cheerlot/src/main/java/com/gms/cheerlot/lineup/repository/TeamRepository.java
+++ b/cheerlot/src/main/java/com/gms/cheerlot/lineup/repository/TeamRepository.java
@@ -227,10 +227,14 @@ public class TeamRepository {
             return null;
         }
         if (prop.getRichText() != null && !prop.getRichText().isEmpty()) {
-            return prop.getRichText().get(0).getPlainText();
+            return prop.getRichText().stream()
+                    .map(PageProperty.RichText::getPlainText)
+                    .collect(java.util.stream.Collectors.joining());
         }
         if (prop.getTitle() != null && !prop.getTitle().isEmpty()) {
-            return prop.getTitle().get(0).getPlainText();
+            return prop.getTitle().stream()
+                    .map(PageProperty.RichText::getPlainText)
+                    .collect(java.util.stream.Collectors.joining());
         }
         return null;
     }


### PR DESCRIPTION
## 개요
Notion RichText에서 첫 번째 블록만 읽어 가사 줄바꿈이 실제 개행이 아닌 리터럴 `\n`으로 전달되는 버그 수정

## 변경 사항
- `CheerSongRepository`, `PlayerRepository`, `TeamRepository`의 `getText()`에서 전체 RichText 블록을 합치도록 수정

## 관련 이슈
- closes #17
